### PR TITLE
fix: error on undo at beginning of history

### DIFF
--- a/crates/fl-cli/src/main.rs
+++ b/crates/fl-cli/src/main.rs
@@ -2257,9 +2257,21 @@ fn main() -> Result<()> {
                 repo.undo(request)?
             };
 
-            println!("undo target event: {}", result.target_event_id);
+            let short_target = &result.target_event_id.to_string()[..8];
             if let Some(checkpoint_id) = result.restored_checkpoint_event {
-                println!("restored commit event: {}", checkpoint_id);
+                let short_restored = &checkpoint_id.to_string()[..8];
+                println!(
+                    "{}  undid event {}  restored commit {}",
+                    "undo".red().bold(),
+                    short_target.yellow(),
+                    short_restored.green()
+                );
+            } else {
+                println!(
+                    "{}  undid event {}",
+                    "undo".red().bold(),
+                    short_target.yellow()
+                );
             }
         }
         Command::Record { paths } => {

--- a/crates/fl-core/src/repo.rs
+++ b/crates/fl-core/src/repo.rs
@@ -3610,6 +3610,12 @@ impl Repo {
         request: &UndoRequest,
     ) -> Result<UndoResult> {
         let target = resolve_target_event(events, request)?;
+
+        // Cannot undo the Init event — there is nothing before it.
+        if matches!(target.kind, EventKind::Init(_)) {
+            bail!("nothing to undo — already at the beginning of history");
+        }
+
         let mode = to_undo_mode(request, target.id);
 
         let mut restored_checkpoint_event = None;
@@ -12614,6 +12620,21 @@ mod tests {
         let err = repo.undo(UndoRequest::N(3)).unwrap_err();
         assert!(
             err.to_string().contains("checkpoint(s) exist before HEAD"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn undo_at_beginning_of_history_errors() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let repo = Repo::at(dir.path());
+        repo.init().expect("repo init should succeed");
+
+        // No checkpoints — only Init event exists
+        let err = repo.undo(UndoRequest::Last).unwrap_err();
+        assert!(
+            err.to_string().contains("nothing to undo"),
             "unexpected error: {}",
             err
         );


### PR DESCRIPTION
## Summary
- Reject `fl undo` when the only event is Init, returning a clear error ("nothing to undo — already at the beginning of history") instead of silently creating a meaningless undo event with exit code 0
- Improve undo CLI output to use short event IDs with color formatting instead of raw UUIDs

## Test plan
- [x] New unit test `undo_at_beginning_of_history_errors` verifies the error
- [x] All 16 existing undo tests pass

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)